### PR TITLE
Instant blueprint fix

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -624,13 +624,15 @@ local function on_creation( event )
             debug_print("No valid note target found")
             ent.destroy()
         end
-
-    elseif (ent.name == "sticky-note" or ent.name == "sticky-sign") then
-		ent.destructible = false
-		ent.operable = false
-    
+		
     elseif ent.name ~= "entity-ghost" then -- when a normal item is placed figure out what ghosts are destroyed
         debug_print("Placed nonghost")
+		
+		if (ent.name == "sticky-note" or ent.name == "sticky-sign") then
+			ent.destructible = false
+			ent.operable = false
+		end
+		
         local x = ent.position.x
         local y = ent.position.y
         local invis_notes = ent.surface.find_entities_filtered{name="invis-note",area={{x-10,y-10},{x+10, y+10}}}

--- a/control.lua
+++ b/control.lua
@@ -633,6 +633,24 @@ local function on_creation( event )
 			ent.operable = false
 		end
 		
+		-- Suggestion: uncomment this part and remove the original 20x20 search.
+		-- In case invis-note was revived before this entity, we need to bind invis-note with this entity again because its unit_number is changed.
+		--[[
+		local pos = ent.position
+		local x = pos.x
+		local y = pos.y
+		local invis_notes = ent.surface.find_entities_filtered{name = "invis-note", force = ent.force, area = {{x - 0.01, y - 0.01}, {x + 0.01, y + 0.01}}, limit = 1}
+		if #invis_notes > 0 then
+			local invis_note = invis_notes[1]
+			local note = get_note(invis_note)
+			if note then
+				update_note_target(note, ent)
+			else
+				destroy_note(note)
+			end
+		end
+		--]]
+		
         local x = ent.position.x
         local y = ent.position.y
         local invis_notes = ent.surface.find_entities_filtered{name="invis-note",area={{x-10,y-10},{x+10, y+10}}}

--- a/control.lua
+++ b/control.lua
@@ -587,7 +587,7 @@ local function on_creation( event )
 		local note_targets = ent.surface.find_entities_filtered{name = "entity-ghost", position = ent.position, force = ent.force, limit = 1}
 		if #note_targets > 0 then
 			local target = note_targets[1]
-			if target.valid or get_note(target) == nil then
+			if target.valid and get_note(target) == nil then
 				note_target = target
 			end
 		end
@@ -597,7 +597,7 @@ local function on_creation( event )
 			for _, target in pairs(note_targets) do
 				debug_print("target"..target.name)
 				if target.prototype.has_flag("player-creation") then
-					if target.valid or get_note(target) == nil then
+					if target.valid and get_note(target) == nil then
 						note_target = target
 					end
 					break

--- a/control.lua
+++ b/control.lua
@@ -367,29 +367,6 @@ local function add_note( entity )
 end
 
 --------------------------------------------------------------------------------------
-local function update_instant_blueprints_enabled()
-    if game.active_mods['instant-blueprints'] then
-        global.instant_blueprints_enabled = true
-    elseif game.active_mods['creative-mode'] then
-        global.instant_blueprints_enabled = remote.call("creative-mode","is_enabled")
-    else
-        global.instant_blueprints_enabled = false
-    end
-    debug_print("instant blueprints: ",global.instant_blueprints_enabled)
-end
-
-local function instant_blueprint_mods_changed()
-    debug_print("on mods changed")
-
-    if game.active_mods['creative-mode'] then
-        script.on_event(remote.call("creative-mode","on_enabled"), update_instant_blueprints_enabled)
-        script.on_event(remote.call("creative-mode","on_disabled"), update_instant_blueprints_enabled)
-    end
-
-    update_instant_blueprints_enabled()
-end
-
---------------------------------------------------------------------------------------
 local function init_globals()
     -- initialize or update general globals of the mod
     debug_print( "init_globals" )
@@ -400,7 +377,6 @@ local function init_globals()
     global.notes_by_invis = global.notes_by_invis or {}
     global.notes_by_target = global.notes_by_target or {}
     global.n_note = global.n_note or 0
-    global.instant_blueprints_enabled = global.instant_blueprints_enabled or false
 end
 
 --------------------------------------------------------------------------------------
@@ -437,14 +413,12 @@ local function on_init()
     debug_print( "on_init" )
     init_globals()
     init_players()
-    instant_blueprint_mods_changed()
 end
 
 script.on_init(on_init)
 
 --------------------------------------------------------------------------------------
 local function on_configuration_changed(data)
-    instant_blueprint_mods_changed()
 
     -- detect any mod or game version change
     debug_print("Config changed ")


### PR DESCRIPTION
Refectored the code so it doesn't need to know the status of instant blueprint (more generic). The last commit (3a2a0f6) removed global.instant_blueprints_enabled entirely.

Also fixed the bug when Sticky Note or Sticky Sign is built, and the player presses ALT+W, a new invis-note is created even if there is already one there.

The 3rd commit (b7a908e) contains comment for linking the revived entity with invis-note, after the 20x20 reach is reworked.